### PR TITLE
Updated and Minified lua lsp config according to docs

### DIFF
--- a/lua/lsp/lua.lua
+++ b/lua/lsp/lua.lua
@@ -1,38 +1,47 @@
 -- https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)
-USER = vim.fn.expand('$USER')
+-- USER = vim.fn.expand('$USER')
+-- Get OS name
+local jit = require("jit")
 
-local sumneko_root_path = ""
-local sumneko_binary = ""
+-- Since your lang server are in ~/.config/neovim we can use `stdpath`
+local sumneko_root_path = string.format("%s/lua-language-server", vim.fn.stdpath("config"))
+local sumneko_binary = string.format("%s/bin/%s/lua-language-server", sumneko_root_path, jit.os)
 
-if vim.fn.has("mac") == 1 then
-    sumneko_root_path = "/Users/" .. USER .. "/.config/nvim/lua-language-server"
-    sumneko_binary = "/Users/" .. USER .. "/.config/nvim/lua-language-server/bin/macOS/lua-language-server"
-elseif vim.fn.has("unix") == 1 then
-    sumneko_root_path = "/home/" .. USER .. "/.config/nvim/lua-language-server"
-    sumneko_binary = "/home/" .. USER .. "/.config/nvim/lua-language-server/bin/Linux/lua-language-server"
-else
-    print("Unsupported system for sumneko")
+if vim.fn.has("mac") ~= 1 and vim.fn.has("unix") ~= 1 then
+	-- print("Unsupported system for sumneko")
+	-- This will display a warning type message
+	vim.cmd([[echohl WarningMsg | echomsg "Unsupported system for sumneko" | echohl None]])
 end
 
-require'lspconfig'.sumneko_lua.setup {
-    capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities()),
-    cmd = {sumneko_binary, "-E", sumneko_root_path .. "/main.lua"},
-    settings = {
-        Lua = {
-            runtime = {
-                -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
-                version = 'LuaJIT',
-                -- Setup your lua path
-                path = vim.split(package.path, ';')
-            },
-            diagnostics = {
-                -- Get the language server to recognize the `vim` global
-                globals = {'vim'}
-            },
-            workspace = {
-                -- Make the server aware of Neovim runtime files
-                library = {[vim.fn.expand('$VIMRUNTIME/lua')] = true, [vim.fn.expand('$VIMRUNTIME/lua/vim/lsp')] = true}
-            }
-        }
-    }
-}
+local runtime_path = vim.split(package.path, ";")
+table.insert(runtime_path, "lua/?.lua")
+table.insert(runtime_path, "lua/?/init.lua")
+
+require("lspconfig").sumneko_lua.setup({
+	capabilities = require("cmp_nvim_lsp").update_capabilities(vim.lsp.protocol.make_client_capabilities()),
+	cmd = { sumneko_binary, "-E", sumneko_root_path .. "/main.lua" },
+	settings = {
+		Lua = {
+			runtime = {
+				-- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
+				version = "LuaJIT",
+				-- Setup your lua path
+				path = runtime_path,
+			},
+			diagnostics = {
+				-- Get the language server to recognize the `vim` global
+				globals = { "vim" },
+			},
+			workspace = {
+				-- Make the server aware of Neovim runtime files
+				library = {
+					library = vim.api.nvim_get_runtime_file("", true),
+					-- Since everyone has more ram make lsp take up more memory for performance
+					maxPreload = 2000,
+					preloadFileSize = 1000,
+				},
+			},
+			telemetry = { enable = false },
+		},
+	},
+})


### PR DESCRIPTION
In neovim we have jit library which can help us in determining OS type

Since you've placed lua-language-server in standard neovim config path
we can use `vim.fn.stdpath`

Also updated the config according to nvim-lspconfig lua server docs

The only caveat is that I don't have MacOS, but I did test your setup
with these changes on Ubuntu vm and Everything worked fine