### PR TITLE
chore(git): remove unused gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-undodir


### PR DESCRIPTION
Hello :)

Just a quick fix to remove the unused `undodir` from the gitignore file.

I'm not 100% sure but since the cleaning of your settings.lua in december (9b825db09b740862331daa4a62495488720365e5) I don't see this directory anymore.