### PR TITLE
feat(lsp): use config to load lsp servers

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -42,16 +42,16 @@ EcoVim = {
   -- Load servers (They will be automatically installed after next "Sync plugins" launch)
   -- Check installed servers by :LspInstallInfo
   lsp = {
-    'bash',
-    'css',
-    'eslint',
-    'graphql',
-    'html',
-    'json',
-    'lua',
-    'tailwind',
-    'tsserver',
-    'vue2'
+    -- 'bash',
+    -- 'css',
+    -- 'eslint',
+    -- 'graphql',
+    -- 'html',
+    -- 'json',
+    -- 'lua',
+    -- 'tailwind',
+    -- 'tsserver',
+    -- 'vue2'
   }
 }
 

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -37,5 +37,21 @@ EcoVim = {
   statusline = {
     path_enabled = true,
     path = 'relative' -- absolute/relative
+  },
+  -- LSP settings (for overriding per client)
+  -- Load servers (They will be automatically installed after next "Sync plugins" launch)
+  -- Check installed servers by :LspInstallInfo
+  lsp = {
+    'bash',
+    'css',
+    'eslint',
+    'graphql',
+    'html',
+    'json',
+    'lua',
+    'tailwind',
+    'tsserver',
+    'vue2'
   }
 }
+

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -42,16 +42,18 @@ EcoVim = {
   -- Load servers (They will be automatically installed after next "Sync plugins" launch)
   -- Check installed servers by :LspInstallInfo
   lsp = {
-    -- 'bash',
-    -- 'css',
-    -- 'eslint',
-    -- 'graphql',
-    -- 'html',
-    -- 'json',
-    -- 'lua',
-    -- 'tailwind',
-    -- 'tsserver',
-    -- 'vue2'
+    servers = {
+      -- 'bash',
+      -- 'css',
+      -- 'eslint',
+      -- 'graphql',
+      -- 'html',
+      -- 'json',
+      -- 'lua',
+      -- 'tailwind',
+      -- 'tsserver',
+      -- 'vue2'
+    }
   }
 }
 

--- a/lua/lsp/config.lua
+++ b/lua/lsp/config.lua
@@ -30,17 +30,6 @@ for type, icon in pairs(signs) do
   vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
 end
 
--- LSP settings (for overriding per client)
--- Load servers (They will be automatically installed after next "Sync plugins" launch)
--- Check installed servers by :LspInstallInfo
-
--- require('lsp.servers.bash')
--- require('lsp.servers.css')
--- require('lsp.servers.eslint')
--- require('lsp.servers.graphql')
--- require('lsp.servers.html')
--- require('lsp.servers.json')
--- require('lsp.servers.lua')
--- require('lsp.servers.tailwind')
--- require('lsp.servers.tsserver')
--- require('lsp.servers.vue2')
+for _,lsp in ipairs(EcoVim.lsp) do
+  require('lsp.servers.' .. lsp)
+end

--- a/lua/lsp/config.lua
+++ b/lua/lsp/config.lua
@@ -30,6 +30,6 @@ for type, icon in pairs(signs) do
   vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
 end
 
-for _,lsp in ipairs(EcoVim.lsp) do
-  require('lsp.servers.' .. lsp)
+for _,server_name in ipairs(EcoVim.lsp.servers) do
+  require('lsp.servers.' .. server_name)
 end


### PR DESCRIPTION
Hello,

I had an idea, I don't know if you will like it :D

Why not move the loading of LSPs directly from the `lua/config.lua` file, which will allow us to have less file to modify if we want to use ecovim.

What do you think about it?