### PR TITLE
fix(plugin): use main branch instead of master for toggleterm

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -88,7 +88,7 @@ local function init()
   use {'AndrewRadev/switch.vim'}
   use {'AndrewRadev/splitjoin.vim'}
   use {'numToStr/Comment.nvim', config = "require('plugins.comment')"}
-  use {'akinsho/nvim-toggleterm.lua', config = "require('plugins.toggleterm')"}
+  use {'akinsho/nvim-toggleterm.lua', branch = 'main', config = "require('plugins.toggleterm')"}
   use {'tpope/vim-repeat'}
   use {'tpope/vim-speeddating'}
   use {'tpope/vim-surround'}


### PR DESCRIPTION
Hello !

Since a few hours I can't update nvim-toggleterm because Packer tries to update it on the master branch when it doesn't exist on the directory.

I just saw a way out on Github with a fix: 
https://github.com/wbthomason/packer.nvim/issues/86


