### PR TITLE
fix(which-key): use the right command to open Alpha

### DIFF
--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -88,7 +88,7 @@ local mappings = {
 
   ["/"] = {
     name = "Dashboard",
-    ["/"] = { '<cmd>Dashboard<CR>',                        'open dashboard' },
+    ["/"] = { '<cmd>Alpha<CR>',                        'open dashboard' },
     ["c"] = { ':e $MYVIMRC<CR>',                           'open init' },
     ["s"] = { '<cmd>PackerSync<CR>',                       'packer sync' },
     ["i"] = { '<cmd>PackerInstall<CR>',                    'packer install' },


### PR DESCRIPTION
Hey :)

Following the change for "Alpha", I just fixed the which-key shortcut to open the dashboard