### PR TITLE
Get rid of inline errors/warnings

### DIFF
--- a/lua/lsp/setup.lua
+++ b/lua/lsp/setup.lua
@@ -22,6 +22,7 @@ local lspconfig = require("lspconfig")
 local handlers = {
   ["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, { border = EcoVim.ui.float.border }),
   ["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, { border = EcoVim.ui.float.border }),
+  ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, { virtual_text = false }),
 }
 
 local function on_attach(client, bufnr)


### PR DESCRIPTION
Ideally this should be a toggle, but inline warnings and errors can really clutter up the buffer. These errors and warnings can be viewed via local diagnostics anyway, which appears below the buffer. Therefore I suggest keeping the inline messages disabled by default for now.