### PR TITLE
feat(lsp): create option to toggle inline messages

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -33,6 +33,9 @@ EcoVim = {
   statusline = {
     path_enabled = true,
     path = 'relative' -- absolute/relative
-  }
+  },
+  lsp = {
+    virtual_text = true, -- show virtual text (errors, warnings, info) inline messages
+  },
 }
 

--- a/lua/lsp/setup.lua
+++ b/lua/lsp/setup.lua
@@ -22,6 +22,7 @@ local lspconfig = require("lspconfig")
 local handlers = {
   ["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, { border = EcoVim.ui.float.border }),
   ["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, { border = EcoVim.ui.float.border }),
+  ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, { virtual_text = EcoVim.lsp.virtual_text }),
 }
 
 local function on_attach(client, bufnr)


### PR DESCRIPTION
Provides the option to toggle inline LSP messages, errors, and warnings from the lua/config.lua file which provides the EcoVim table. The value can be changed using the boolean property of the lsp sub-table, called virtual_text.  
For example:  
```lua
  lsp = {
    virtual_text = false,
  },
```  
This property is then carried over to lua/lsp/setup.lua, inside the local handlers, under textDocument/publishDiagnostics, where virtual_text is set to the value of EcoVim.lsp.virtual_text.  
```lua
["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, { virtual_text = EcoVim.lsp.virtual_text }),
```