### PR TITLE
fix(tree): use bufferline.api to set offset

### DIFF
--- a/lua/plugins/tree.lua
+++ b/lua/plugins/tree.lua
@@ -1,6 +1,6 @@
 local utils = require('utils')
 local nvim_tree_events = require('nvim-tree.events')
-local bufferline_state = require('bufferline.state')
+local bufferline_api = require('bufferline.api')
 
 local TREE_WIDTH = 40
 
@@ -176,9 +176,9 @@ require'nvim-tree'.setup {
 vim.api.nvim_set_keymap("n", "<C-e>", "<cmd>lua require'nvim-tree'.toggle()<CR>", { noremap = true, silent = true })
 
 nvim_tree_events.on_tree_open(function ()
-    bufferline_state.set_offset(TREE_WIDTH + 1, utils.add_whitespaces(13) .. 'File Explorer')
+    bufferline_api.set_offset(TREE_WIDTH + 1, utils.add_whitespaces(13) .. 'File Explorer')
 end)
 
 nvim_tree_events.on_tree_close(function ()
-    bufferline_state.set_offset(0)
+    bufferline_api.set_offset(0)
 end)


### PR DESCRIPTION
Hi,

`bufferline.state` to set offset is now deprecated, we need to use `bufferline.api`