### PR TITLE
fix: return nvim-notify notification record from vim.notify

### DIFF
--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -1,14 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "Lua.diagnostics.globals": [
-    "vim",
-    "bit",
-    "require"
-  ],
-    "workspace.library": [
-        "/Users/dillon/.local/share/nvim/site/pack/packer/start/neodev.nvim/types/stable",
-        "/opt/homebrew/Cellar/neovim/0.9.0/share/nvim/runtime/lua",
-        "/Users/dillon/Code/ecovim/lua",
-        "${3rd}/luv/library"
-    ]
+  "Lua.diagnostics.globals": ["vim", "bit", "require"]
 }

--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -4,5 +4,11 @@
     "vim",
     "bit",
     "require"
-  ]
+  ],
+    "workspace.library": [
+        "/Users/dillon/.local/share/nvim/site/pack/packer/start/neodev.nvim/types/stable",
+        "/opt/homebrew/Cellar/neovim/0.9.0/share/nvim/runtime/lua",
+        "/Users/dillon/Code/ecovim/lua",
+        "${3rd}/luv/library"
+    ]
 }

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -336,7 +336,7 @@ return {
 						return
 					end
 				end
-				require("notify")(msg, ...)
+				return require("notify")(msg, ...)
 			end
 		end,
 	},


### PR DESCRIPTION
This change is needed to support users of EcoVim who are integrating with [tsc.nvim](https://github.com/dmmulroy/tsc.nvim). `tsc.nvim` takes advantage of the fact that `nvim-notify` [returns a record](https://github.com/rcarriga/nvim-notify/blob/master/doc/nvim-notify.txt#L78-L92) that can be used to updated existing notifications.

This change updates the over `vim.notify` override to return the notification record from `nvim-notify`

See https://github.com/dmmulroy/tsc.nvim/issues/2 for further discussion.