### PR TITLE
🪛 [fix] `context_commentstring` deprecated.

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,4 +1,4 @@
-require 'nvim-treesitter.configs'.setup {
+require 'ts_context_commentstring'.setup {
   ensure_installed = {
     "tsx",
     "typescript",
@@ -37,11 +37,6 @@ require 'nvim-treesitter.configs'.setup {
 
   indent = {
     enable = true
-  },
-
-  context_commentstring = {
-    enable = true,
-    enable_autocmd = false,
   },
 
   textobjects = {


### PR DESCRIPTION
by JoosepAlviste/nvim-ts-context-commentstring#82