### PR TITLE
✨[fixed] fix `nvim-ufo` upgrade name deprecated.

### DIFF
--- a/lua/config/lsp/setup.lua
+++ b/lua/config/lsp/setup.lua
@@ -139,5 +139,5 @@ require("mason-lspconfig").setup_handlers {
 
 require("ufo").setup({
   fold_virt_text_handler = ufo_config_handler,
-  close_fold_kinds = { "imports" },
+  close_fold_kinds_for_ft = { "imports" },
 })


### PR DESCRIPTION
- by kevinhwang91/nvim-ufo@7b14dd650b57291a49f037f1ede325d46e08b258